### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You can open a new screen session by running the command:
 screen -S aadash
 ```
 
-This will automatically enter a new terminal session, where you can start the server using `Rescript app.R`. To disconnect, you can press "Control-A", then "Control-D". To reconnect (e.g. to stop or restart the server), you type `screen -R aadash`.
+This will automatically enter a new terminal session, where you can start the server using `Rscript app.R`. To disconnect, you can press "Control-A", then "Control-D". To reconnect (e.g. to stop or restart the server), you type `screen -R aadash`.
 
 #### Securing the server
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,17 @@ App.R provides an R/Shiny app that can be run locally within R ([Rstudio](https:
 
 Input CSV file is the raw downloaded "Consultations" CSV from the reporting section of Attend Anywhere. 
 
-A demonstration of the latest build will shortly be available at [aadash.org](https://aadash.org).
+A demonstration of the latest build is available at [aadash.org](https://aadash.org).
 
 ## Getting started
 
-The software will soon be available at [aadash.org](https://aadash.org). It can also be self-hosted. Pointers for installation on Debian-based linux systems are shown below, but additional linux experience is likely to be required.
+The software is be available at [aadash.org](https://aadash.org).
+
+Alternatively, you can download app.R from this page, and run it within R ([Rstudio](https://rstudio.com/)) on your computer.
+
+## Setting up your own server
+
+If you want to host AADash so it can be used by other individuals within your organisation without them needing to install RStudio, or use the hosted version at [aadash.org](https://aadash.org), the software can also be self-hosted. Pointers for installation on Debian-based linux systems are shown below, but additional linux experience is likely to be required.
 
 ### Self-hosting
 


### PR DESCRIPTION
This request fixes a typo in the README, and clarifies the installation instructions provided previously. This request also changes details of the hosting to the present tense, because the website is now accessible at https://aadash.org